### PR TITLE
Fix undefined array key warnings for style.color.gradient

### DIFF
--- a/popup.php
+++ b/popup.php
@@ -88,9 +88,10 @@ function filter_render_block( $block_content, $block, \WP_Block $instance ) {
 		$styles['background-color'] = "var(--wp--preset--color--{$block['attrs']['backgroundColor']}) !important";
 	}
 
-	if ( ! empty( $block['attrs']['style']['color']['gradient'] ) ) {
+	$gradient = $block['attrs']['style']['color']['gradient'] ?? '';
+	if ( ! empty( $gradient ) ) {
 		$styles['background-color'] = 'transparent !important';
-		$styles['background-image'] = "{$block['attrs']['style']['color']['gradient']} !important";
+		$styles['background-image'] = "{$gradient} !important";
 	}
 
 	$styles = array_map( function ( $style, $prop ) {


### PR DESCRIPTION
## Summary

- Fixes PHP 8.x warnings: *Undefined array key "style"* and *Trying to access array offset on null* that occur in `filter_render_block()` when `$block['attrs']['style']` is not set
- Uses the null coalescing operator (`??`) to safely extract the nested `style.color.gradient` value before the `empty()` check

## Test plan

- [ ] Render a popup block without a gradient set — no PHP warnings should appear
- [ ] Render a popup block with a gradient set — gradient styles should still apply correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2Fsite-editor.php%22%2C%22login%22%3Atrue%2C%22steps%22%3A%5B%7B%22step%22%3A%22installTheme%22%2C%22themeData%22%3A%7B%22resource%22%3A%22wordpress.org%2Fthemes%22%2C%22slug%22%3A%22twentytwentyfive%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub-proxy.com%2Fproxy%2F%3Frepo%3Dhumanmade%2Fpopup%26branch%3Dpr-11-built%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->