### PR TITLE
Register out-of-the-box block patterns

### DIFF
--- a/patterns/click-popup.php
+++ b/patterns/click-popup.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Pattern: Click-Triggered Popup
+ *
+ * @package hm-popup
+ */
+
+return [
+	'slug'        => 'hm-popup/click-popup',
+	'title'       => __( 'Click-Triggered Popup', 'hm-popup' ),
+	'description' => __( 'A button that opens a modal popup when clicked.', 'hm-popup' ),
+	'categories'  => [ 'hm-popup', 'buttons' ],
+	'content'     => '<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"url":"#click-popup","metadata":{"popup":"open"}} -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="#click-popup">Open popup</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->
+
+<!-- wp:hm/popup {"trigger":"click","anchor":"click-popup","opacity":75} -->
+<dialog class="wp-block-hm-popup" id="click-popup" data-trigger="click" data-expiry="7" data-backdrop-opacity="0.75" data-dismiss-on-submit="false" closedby="any"><!-- wp:group {"style":{"shadow":"var:preset|shadow|natural","spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"backgroundColor":"white","layout":{"type":"constrained","contentSize":"560px"}} -->
+<div class="wp-block-group has-white-background-color has-background" style="box-shadow:var(--wp--preset--shadow--natural);padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:heading {"textAlign":"center","level":3} -->
+<h3 class="wp-block-heading has-text-align-center">Popup title</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">Add your message or content here.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"url":"#close","metadata":{"popup":"close"}} -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="#close">Close</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></dialog>
+<!-- /wp:hm/popup -->',
+];

--- a/patterns/exit-intent.php
+++ b/patterns/exit-intent.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Pattern: Exit Intent Popup
+ *
+ * @package hm-popup
+ */
+
+return [
+	'slug'        => 'hm-popup/exit-intent',
+	'title'       => __( 'Exit Intent Popup', 'hm-popup' ),
+	'description' => __( 'A modal popup that appears when the visitor is about to leave the page.', 'hm-popup' ),
+	'categories'  => [ 'hm-popup' ],
+	'content'     => '<!-- wp:hm/popup {"trigger":"exit","anchor":"exit-intent-popup","opacity":75} -->
+<dialog class="wp-block-hm-popup" id="exit-intent-popup" data-trigger="exit" data-expiry="7" data-backdrop-opacity="0.75" data-dismiss-on-submit="false" closedby="any"><!-- wp:group {"style":{"shadow":"var:preset|shadow|natural","spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"backgroundColor":"white","layout":{"type":"constrained","contentSize":"560px"}} -->
+<div class="wp-block-group has-white-background-color has-background" style="box-shadow:var(--wp--preset--shadow--natural);padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:heading {"textAlign":"center","level":3} -->
+<h3 class="wp-block-heading has-text-align-center">Before you go&hellip;</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">Sign up for our newsletter and never miss an update.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"url":"#close","metadata":{"popup":"close"}} -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="#close">No thanks</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></dialog>
+<!-- /wp:hm/popup -->',
+];

--- a/patterns/left-popout.php
+++ b/patterns/left-popout.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Pattern: Left Popout Panel
+ *
+ * @package hm-popup
+ */
+
+return [
+	'slug'        => 'hm-popup/left-popout',
+	'title'       => __( 'Left Popout Panel', 'hm-popup' ),
+	'description' => __( 'A button that slides in a panel from the left edge of the screen.', 'hm-popup' ),
+	'categories'  => [ 'hm-popup', 'buttons' ],
+	'content'     => '<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"url":"#left-popout","metadata":{"popup":"open"}} -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="#left-popout">Open menu</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->
+
+<!-- wp:hm/popup {"trigger":"click","anchor":"left-popout","opacity":75,"className":"is-style-side--left"} -->
+<dialog class="wp-block-hm-popup is-style-side--left" id="left-popout" data-trigger="click" data-expiry="7" data-backdrop-opacity="0.75" data-dismiss-on-submit="false" closedby="any"><!-- wp:group {"style":{"dimensions":{"minHeight":"100vh"},"border":{"right":{"color":"#dddddd","width":"4px","style":"solid"}},"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"backgroundColor":"white","layout":{"type":"constrained","contentSize":"320px"}} -->
+<div class="wp-block-group has-white-background-color has-background" style="border-right-color:#dddddd;border-right-style:solid;border-right-width:4px;min-height:100vh;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Navigation</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Add links or content here.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"url":"#close","metadata":{"popup":"close"},"className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button" href="#close">Close</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></dialog>
+<!-- /wp:hm/popup -->',
+];

--- a/patterns/page-load.php
+++ b/patterns/page-load.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Pattern: Page Load Popup
+ *
+ * @package hm-popup
+ */
+
+return [
+	'slug'        => 'hm-popup/page-load',
+	'title'       => __( 'Page Load Popup', 'hm-popup' ),
+	'description' => __( 'A modal popup that appears automatically when the page loads.', 'hm-popup' ),
+	'categories'  => [ 'hm-popup' ],
+	'content'     => '<!-- wp:hm/popup {"trigger":"load","anchor":"page-load-popup","opacity":75} -->
+<dialog class="wp-block-hm-popup" id="page-load-popup" data-trigger="load" data-expiry="7" data-backdrop-opacity="0.75" data-dismiss-on-submit="false" closedby="any"><!-- wp:group {"style":{"shadow":"var:preset|shadow|natural","spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"backgroundColor":"white","layout":{"type":"constrained","contentSize":"560px"}} -->
+<div class="wp-block-group has-white-background-color has-background" style="box-shadow:var(--wp--preset--shadow--natural);padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:heading {"textAlign":"center","level":3} -->
+<h3 class="wp-block-heading has-text-align-center">Welcome!</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">Thanks for visiting. Check out our latest offers below.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"url":"#close","metadata":{"popup":"close"}} -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="#close">Close</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></dialog>
+<!-- /wp:hm/popup -->',
+];

--- a/patterns/right-popout.php
+++ b/patterns/right-popout.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Pattern: Right Popout Panel
+ *
+ * @package hm-popup
+ */
+
+return [
+	'slug'        => 'hm-popup/right-popout',
+	'title'       => __( 'Right Popout Panel', 'hm-popup' ),
+	'description' => __( 'A button that slides in a panel from the right edge of the screen.', 'hm-popup' ),
+	'categories'  => [ 'hm-popup', 'buttons' ],
+	'content'     => '<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"right"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"url":"#right-popout","metadata":{"popup":"open"}} -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="#right-popout">Open panel</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->
+
+<!-- wp:hm/popup {"trigger":"click","anchor":"right-popout","opacity":75,"className":"is-style-side--right"} -->
+<dialog class="wp-block-hm-popup is-style-side--right" id="right-popout" data-trigger="click" data-expiry="7" data-backdrop-opacity="0.75" data-dismiss-on-submit="false" closedby="any"><!-- wp:group {"style":{"dimensions":{"minHeight":"100vh"},"border":{"left":{"color":"#dddddd","width":"4px","style":"solid"}},"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"backgroundColor":"white","layout":{"type":"constrained","contentSize":"320px"}} -->
+<div class="wp-block-group has-white-background-color has-background" style="border-left-color:#dddddd;border-left-style:solid;border-left-width:4px;min-height:100vh;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Quick info</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Add links or content here.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"right"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"url":"#close","metadata":{"popup":"close"},"className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button" href="#close">Close</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></dialog>
+<!-- /wp:hm/popup -->',
+];

--- a/patterns/tooltip.php
+++ b/patterns/tooltip.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Pattern: Anchored Tooltip
+ *
+ * @package hm-popup
+ */
+
+return [
+	'slug'        => 'hm-popup/tooltip',
+	'title'       => __( 'Anchored Tooltip', 'hm-popup' ),
+	'description' => __( 'An info icon that shows a tooltip above it when hovered.', 'hm-popup' ),
+	'categories'  => [ 'hm-popup' ],
+	'content'     => '<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><a href="#hover-tooltip">&#8505;&#65039;</a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:hm/popup {"trigger":"hover","anchor":"hover-tooltip","opacity":0,"dismissible":false,"className":"is-style-anchored","anchorPosition":"top","layout":{"type":"constrained","contentSize":"240px"}} -->
+<dialog class="wp-block-hm-popup is-style-anchored" id="hover-tooltip" data-trigger="hover" data-expiry="7" data-anchor-position="top" data-backdrop-opacity="0" data-dismiss-on-submit="false" closedby="any"><!-- wp:group {"style":{"shadow":"var:preset|shadow|natural","spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|40","bottom":"var:preset|spacing|30","left":"var:preset|spacing|40"}}},"backgroundColor":"white","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-white-background-color has-background" style="box-shadow:var(--wp--preset--shadow--natural);padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--40)"><!-- wp:paragraph {"style":{"typography":{"fontSize":"0.875rem"}}} -->
+<p style="font-size:0.875rem">This is a helpful tooltip. Add your explanatory text here.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></dialog>
+<!-- /wp:hm/popup -->',
+];

--- a/popup.php
+++ b/popup.php
@@ -153,4 +153,16 @@ function action_init() : void {
 			'label' => __( 'Anchored', 'hm-popup' ),
 		]
 	);
+
+	register_block_pattern_category(
+		'hm-popup',
+		[ 'label' => __( 'Popups', 'hm-popup' ) ]
+	);
+
+	foreach ( glob( __DIR__ . '/patterns/*.php' ) as $pattern_file ) {
+		$pattern = include $pattern_file;
+		if ( is_array( $pattern ) && isset( $pattern['slug'] ) ) {
+			register_block_pattern( $pattern['slug'], $pattern );
+		}
+	}
 }

--- a/tests/popup-options.spec.js
+++ b/tests/popup-options.spec.js
@@ -301,12 +301,21 @@ test.describe( 'Popup Block Options', () => {
 			editor,
 			page,
 		} ) => {
-			// Insert a link that targets the popup anchor.
+			// Insert a button linking to the popup anchor (same pattern as
+			// anchoring.spec.js). beforeEach already inserted a click popup,
+			// so we need a specific selector to avoid ambiguity.
 			await editor.insertBlock( {
-				name: 'core/paragraph',
-				attributes: {
-					content: '<a href="#hover-test-popup">Hover me</a>',
-				},
+				name: 'core/buttons',
+				innerBlocks: [
+					{
+						name: 'core/button',
+						attributes: {
+							text: 'Hover me',
+							url: '#hover-test-popup',
+							metadata: { popup: 'open' },
+						},
+					},
+				],
 			} );
 
 			// Insert the popup with hover trigger.
@@ -323,17 +332,21 @@ test.describe( 'Popup Block Options', () => {
 			const postId = await editor.publishPost();
 			await page.goto( `/?p=${ postId }` );
 
-			const dialog = page.locator( '.wp-block-hm-popup' );
-			const triggerLink = page.locator( 'a[href="#hover-test-popup"]' );
+			// Use the popup's specific id to avoid matching the click popup
+			// inserted by beforeEach.
+			const dialog = page.locator( '#hover-test-popup' );
+			const triggerLink = page.locator(
+				'.wp-block-button a[href$="#hover-test-popup"]'
+			);
 
 			// Dialog should not be open initially.
 			await expect( dialog ).not.toHaveAttribute( 'open', '' );
 
-			// Hover over the trigger link.
+			// Hover over the trigger button link.
 			await triggerLink.hover();
 
-			// Dialog should now be visible.
-			await expect( dialog ).toBeVisible();
+			// Dialog should now have the open attribute set by popup.show().
+			await expect( dialog ).toHaveAttribute( 'open', '' );
 		} );
 
 		test( 'undismissible popup cannot be closed via Escape', async ( {


### PR DESCRIPTION
Closes #13

> **Note:** This PR is stacked on top of PR #14 (hover trigger). Please merge #14 first, then update the base of this PR to `main` before merging.

## Summary

Registers a **"Popups"** block pattern category and six ready-to-use patterns so users can get started without building popup layouts from scratch.

## Changes

### `popup.php`
- Registers the `hm-popup` pattern category (`"Popups"`) in `action_init()`.
- Iterates over `patterns/*.php` files and calls `register_block_pattern()` for each.

### `patterns/` (new directory — 6 files)

| Pattern | Slug | Trigger | Notes |
|---------|------|---------|-------|
| Exit Intent Popup | `hm-popup/exit-intent` | exit | Close button; first group has `natural` WP box shadow |
| Page Load Popup | `hm-popup/page-load` | load | Close button; first group has `natural` WP box shadow |
| Click-Triggered Popup | `hm-popup/click-popup` | click | Trigger button + close button; first group has `natural` WP box shadow |
| Left Popout Panel | `hm-popup/left-popout` | click | `is-style-side--left`; first group: `minHeight 100vh`, grey right border |
| Right Popout Panel | `hm-popup/right-popout` | click | `is-style-side--right`; first group: `minHeight 100vh`, grey left border |
| Anchored Tooltip | `hm-popup/tooltip` | hover | `is-style-anchored`, `anchorPosition: top`; ℹ️ icon trigger; requires PR #14 |

## How to test

1. Open the block inserter → **Patterns** tab → **Popups** category.
2. Insert each pattern and verify it looks correct in the editor.
3. Publish and visit the frontend:
   - Exit intent: move cursor out of the window to trigger.
   - Page load: popup opens automatically (clear localStorage first to reset expiry).
   - Click popup / side panels: click the trigger button.
   - Tooltip: hover over the ℹ️ icon — popup appears above it.

https://claude.ai/code/session_01SjvQ7YTxjFF81uSb1WtPAH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjvQ7YTxjFF81uSb1WtPAH)_

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2Fsite-editor.php%22%2C%22login%22%3Atrue%2C%22steps%22%3A%5B%7B%22step%22%3A%22installTheme%22%2C%22themeData%22%3A%7B%22resource%22%3A%22wordpress.org%2Fthemes%22%2C%22slug%22%3A%22twentytwentyfive%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub-proxy.com%2Fproxy%2F%3Frepo%3Dhumanmade%2Fhm-popup-block%26branch%3Dpr-15-built%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->