### PR TITLE
Switch release workflow to manual trigger with version input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,59 +1,98 @@
-name: Version and Release
+name: Release
+
+# Builds the plugin, stamps the version into the source, then creates an
+# immutable tag that already points at the built, versioned code.
+#
+# The tag is created exactly once and is never moved or force-pushed, so
+# Packagist (which requires tags to be immutable) accepts it without conflict.
+#
+# Trigger this manually from the Actions tab and supply the version to cut.
 
 on:
-    release:
-        types:
-            - created
+    workflow_dispatch:
+        inputs:
+            version:
+                description: 'Version to release, without a leading "v" (e.g. 1.2.3)'
+                required: true
+                type: string
 
-permissions:
-    contents: write
+concurrency:
+    group: release-${{ github.event.inputs.version }}
+    cancel-in-progress: false
 
 jobs:
     release:
+        name: Build, tag and publish
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
         steps:
-            - name: Checkout
-              uses: actions/checkout@v4
+            - name: Validate version input
+              run: |
+                  VERSION="${{ github.event.inputs.version }}"
+                  if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+                      echo "::error::Version must be in X.Y.Z format without a leading 'v'. Got: '$VERSION'"
+                      exit 1
+                  fi
+                  echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+                  echo "TAG=v$VERSION" >> "$GITHUB_ENV"
+
+            - name: Check out source
+              uses: actions/checkout@v5
               with:
-                  ref: ${{ github.event.release.tag_name }}
+                  ref: main
                   fetch-depth: 0
 
-            - name: Setup Node
+            - name: Ensure the tag does not already exist
+              run: |
+                  if git ls-remote --tags origin | grep -q "refs/tags/${TAG}$"; then
+                      echo "::error::Tag ${TAG} already exists. Tags are immutable — bump the version and try again."
+                      exit 1
+                  fi
+
+            - name: Set up Node
               uses: actions/setup-node@v4
               with:
-                  node-version: '24'
+                  node-version: 24
                   cache: 'npm'
 
-            - name: Install dependencies
-              run: npm i
+            - name: Install dependencies and build
+              run: |
+                  npm ci
+                  npm run build
 
-            - name: Get version from tag
-              id: version
-              run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+            - name: Stamp version into the plugin
+              run: |
+                  sed -i "s/__VERSION__/${VERSION}/g" popup.php
+                  echo "Stamped plugin header:"
+                  grep -n "Version:" popup.php
 
-            - name: Update version in plugin file
-              run: sed -i "s/__VERSION__/${{ steps.version.outputs.version }}/g" popup.php
-
-            - name: Build
-              run: npm run build
-
-            - name: Commit version update
+            - name: Create the immutable release commit and tag
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git add .
-                  git commit -m "Update version to ${{ steps.version.outputs.version }}"
 
-            - name: Update tag
-              run: |
-                  git tag -f ${{ github.event.release.tag_name }}
-                  git push origin ${{ github.event.release.tag_name }} --force
+                  # build/ is gitignored in source; force-add the compiled assets
+                  # so the tagged tree is self-contained and ready to install.
+                  git add -f build
+                  git add popup.php
+                  git commit -m "Release ${TAG}"
 
-            - name: Create plugin ZIP
+                  git tag -a "${TAG}" -m "Release ${TAG}"
+
+                  # Push ONLY the tag (and the objects it reaches). It is created
+                  # once and never force-pushed, satisfying Packagist's immutability.
+                  git push origin "refs/tags/${TAG}"
+
+            - name: Build distribution ZIP
               run: npm run plugin-zip
 
-            - name: Upload release asset
-              run: |
-                  gh release upload ${{ github.event.release.tag_name }} popup.zip --clobber
+            - name: Publish GitHub release
+              uses: softprops/action-gh-release@v2
+              with:
+                  tag_name: ${{ env.TAG }}
+                  name: ${{ env.TAG }}
+                  generate_release_notes: true
+                  files: popup.zip
               env:
-                  GH_TOKEN: ${{ github.token }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,40 @@ Anchored popups automatically reposition when they would overflow the viewport.
 -   WordPress 6.1+
 -   PHP 7.0+
 
+## Release Process
+
+Releases are cut by the **Release** GitHub Actions workflow
+(`.github/workflows/release.yml`), triggered manually from the Actions tab.
+
+The workflow does everything _before_ the tag exists, then creates the tag
+once and never touches it again — this keeps every tag immutable, which is
+what Packagist requires (it rejects tag updates).
+
+### Creating a release
+
+1. Make sure `main` is green and contains the code you want to ship.
+2. Go to **Actions → Release → Run workflow**.
+3. Enter the version **without** a leading `v` (e.g. `1.2.3`).
+4. Run it.
+
+The workflow will then:
+
+1. Validate the version (must be `X.Y.Z`) and fail fast if the `vX.Y.Z` tag
+    already exists.
+2. Build the production assets (`npm ci && npm run build`).
+3. Stamp the version into `popup.php`, replacing the `__VERSION__` placeholder.
+4. Commit the built assets and stamped version, create an annotated tag
+    `vX.Y.Z` pointing at that commit, and push the tag — once, never
+    force-pushed.
+5. Build the distribution ZIP with `npm run plugin-zip` (`popup.zip`) and
+    publish a GitHub release with auto-generated notes.
+
+The version on `main` is always the literal placeholder `__VERSION__`; the real
+number only ever exists inside a release tag. Follow
+[Semantic Versioning](https://semver.org/). Because tags are immutable, if a
+release was wrong, **publish a new patch version** rather than trying to move a
+tag.
+
 ## License
 
 GPL-2.0-or-later


### PR DESCRIPTION
## What & why

The old `release.yml` triggered on `release: created`. Because the release already existed at a tag, the workflow had to build the plugin, commit the compiled assets, and then **force-push the tag** to move it onto the new commit. Retagging + force-pushing is the behaviour we wanted to get rid of — it breaks Packagist's tag immutability and is generally fragile.

This mirrors the change already made in `hm-query-loop`: the release is now cut from a **manual `workflow_dispatch`** with a `version` input. The tag is created exactly once, already pointing at the built and versioned code, and is never moved or force-pushed.

## Changes

`.github/workflows/release.yml`:

- Trigger changed from `on: release: created` to `on: workflow_dispatch` with a required `version` input (X.Y.Z, no leading `v`).
- Validates the version format and refuses to proceed if the `v<version>` tag already exists.
- Checks out `main`, runs `npm ci && npm run build`, and stamps the version into `popup.php` (`__VERSION__` placeholder).
- Force-adds the gitignored `build/` output so the tagged tree is self-contained, commits, creates an **annotated tag once**, and pushes only that tag — no force push.
- Builds `popup.zip` via the existing `npm run plugin-zip` script and publishes a GitHub release (with generated notes) using `softprops/action-gh-release@v2`.

## How to use

Run the **Release** workflow from the Actions tab and supply the version (e.g. `1.2.3`).

## Notes

- Kept this repo's existing `npm run plugin-zip` mechanism rather than the `git archive` approach `hm-query-loop` uses, since this repo has no `.gitattributes` and `plugin-zip` was already the established tooling here.
- `build-and-release.yml` (the release-branch mirror on push to `main`) is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuiSYc2zyC3snrT5wKS1iA)_

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22landingPage%22%3A%22%2Fwp-admin%2Fsite-editor.php%22%2C%22login%22%3Atrue%2C%22steps%22%3A%5B%7B%22step%22%3A%22installTheme%22%2C%22themeData%22%3A%7B%22resource%22%3A%22wordpress.org%2Fthemes%22%2C%22slug%22%3A%22twentytwentyfive%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub-proxy.com%2Fproxy%2F%3Frepo%3Dhumanmade%2Fhm-popup-block%26branch%3Dpr-16-built%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->